### PR TITLE
Fix resetBreakpoints unbinding

### DIFF
--- a/breakpoints.js
+++ b/breakpoints.js
@@ -19,13 +19,13 @@
 	var lastSize = 0;
 	var interval = null;
 
-	$.fn.resetBreakpoints = function() {
-		$(window).unbind('resize');
-		if (interval) {
-			clearInterval(interval);
-		}
-		lastSize = 0;
-	};
+       $.fn.resetBreakpoints = function() {
+               if (interval) {
+                       clearInterval(interval);
+                       interval = null;
+               }
+               lastSize = 0;
+       };
 	
 	$.fn.setBreakpoints = function(settings) {
 		var options = jQuery.extend({


### PR DESCRIPTION
## Summary
- avoid removing third party `resize` handlers in `resetBreakpoints`

## Testing
- `node -c breakpoints.js`

------
https://chatgpt.com/codex/tasks/task_e_6841a4806d588321ba3c2b50a7bd5fc0