### PR TITLE
Add Jest tests for breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Created by [XOXCO](http://xoxco.com)
 		...
 	});
 
+
+## Tests
+
+Install dependencies and run the Jest suite:
+
+```
+npm install
+npm test
+```
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "breakpoints-test",
+  "version": "1.0.0",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.1.0",
+    "jquery": "^3.7.0"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/test/breakpoints.test.js
+++ b/test/breakpoints.test.js
@@ -1,0 +1,52 @@
+const {JSDOM} = require('jsdom');
+const path = require('path');
+
+jest.useFakeTimers();
+
+function setupDom(width) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  dom.window.innerWidth = width;
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const $ = require('jquery')(dom.window);
+  global.jQuery = $;
+  global.$ = $;
+  // load plugin after jQuery is present
+  require(path.resolve(__dirname, '../breakpoints.js'));
+  return $;
+}
+
+function advance() {
+  // advance timers enough so the interval executes at least once
+  jest.advanceTimersByTime(300);
+}
+
+test('plugin triggers enter and exit events as window size changes', () => {
+  const $ = setupDom(300);
+  const events = [];
+
+  $(window)
+    .on('enterBreakpoint320', () => events.push('enter320'))
+    .on('exitBreakpoint320', () => events.push('exit320'))
+    .on('enterBreakpoint480', () => events.push('enter480'))
+    .on('exitBreakpoint480', () => events.push('exit480'));
+
+  $(window).setBreakpoints({ distinct: true, breakpoints: [320, 480] });
+  advance();
+  expect(events).toEqual([]);
+
+  // grow into first breakpoint
+  window.innerWidth = 350;
+  advance();
+  expect(events).toEqual(['enter320']);
+
+  // grow into second breakpoint
+  window.innerWidth = 500;
+  advance();
+  expect(events.slice(-2)).toEqual(['exit320', 'enter480']);
+
+  // shrink back to first breakpoint
+  window.innerWidth = 430;
+  advance();
+  expect(events.slice(-2)).toEqual(['exit480', 'enter320']);
+});


### PR DESCRIPTION
## Summary
- add Jest, jsdom and jquery config
- create tests for Breakpoints.js using jsdom
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa23b78c83218772518bf2f3112c